### PR TITLE
Add Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,4 @@ Stay updated with the latest developments:
 - Follow HyperWriteAI on [LinkedIn](https://www.linkedin.com/company/othersideai/).
 
 ### Compatibility
-- This project is only compatible with MacOS at this time. 
+- This project is compatible with Mac OS, Windows, and Linux (with X server installed).

--- a/operate/main.py
+++ b/operate/main.py
@@ -11,12 +11,13 @@ import subprocess
 import pyautogui
 import argparse
 import platform
+import Xlib.display
 
 from prompt_toolkit import prompt
 from prompt_toolkit.shortcuts import message_dialog
 from prompt_toolkit.styles import Style as PromptStyle
 from dotenv import load_dotenv
-from PIL import Image, ImageDraw, ImageFont
+from PIL import Image, ImageDraw, ImageFont, ImageGrab
 import matplotlib.font_manager as fm
 from openai import OpenAI
 
@@ -561,12 +562,23 @@ def search(text):
 
 
 def capture_screen_with_cursor(file_path=os.path.join("screenshots", "screenshot.png")):
-    # Use the screencapture utility to capture the screen with the cursor
-    if platform.system() == "Windows":
+    user_platform = platform.system()
+    
+    if user_platform == "Windows":
         screenshot = pyautogui.screenshot()
         screenshot.save(file_path)
-    else:
+    elif user_platform == "Linux":
+        # Use xlib to prevent scrot dependency for Linux
+        screen = Xlib.display.Display().screen()
+        size = screen.width_in_pixels, screen.height_in_pixels
+        screenshot = ImageGrab.grab(bbox=(0, 0, size[0], size[1]))
+        screenshot.save(file_path)
+    elif user_platform == "Darwin": # (Mac OS)
+        # Use the screencapture utility to capture the screen with the cursor
         subprocess.run(["screencapture", "-C", file_path])
+    else:
+        print(f"The platform you're using ({user_platform}) is not currently supported")
+
 
 def extract_json_from_string(s):
     # print("extracting json from string", s)

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ pyperclip==1.8.2
 PyRect==0.2.0
 pyscreenshot==3.1
 PyScreeze==0.1.29
+python3-xlib==0.15
 python-dateutil==2.8.2
 python-dotenv==1.0.0
 pytweening==1.0.7


### PR DESCRIPTION
- This PR adds support for Linux systems with X Server installed (most linux distros). 
- In addition, the system will print an error message when the platform is not Darwin (Mac OS), Windows, or Linux. 
- The README has also been updated to reflect the changes in compatibility.

I chose to use Xlib with PIL's ScreenGrab to prevent requiring the user to install scrot (which is required by PyAutoGUI on Linux).

**NOTE:**
- I have tested this on my Linux machine as well as on Windows.
- Operation on Linux appears fully-functional. 
- Operation on Windows remains the same before and after these commits.
- I am unable to test the result of these commits on Mac OS.