### PR TITLE
feat: add automation installer script for SOC

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,6 @@
 #   Issues: https://github.com/OthersideAI/self-operating-computer/issues
 #   Requires: bash, curl/wget, python3, pip, git
 #
-#   Currently this only work on MacOS systems. 
 #   Please open an issue if you notice any bugs.
 #
 #
@@ -101,18 +100,7 @@ fi
 if ! command_exists git; then
     echo "Git not found. Installing Git..."
     install_packages git
-fi
-
-# Check if the directory exists and is not empty
-if [ -d "self-operating-computer" ] && [ "$(ls -A self-operating-computer)" ]; then
-    echo "Directory 'self-operating-computer' already exists and is not empty. Skipping clone operation..."
-else
-    # Clone the repository
-    run_script "git clone https://github.com/OthersideAI/self-operating-computer.git"
-fi
-
-# Change directory
-cd self-operating-computer || { log_error "Unable to navigate to the project directory."; exit 1; }
+fi 
 
 # Create a Python virtual environment
 run_script "python3 -m venv venv"


### PR DESCRIPTION
This pull request introduces an installation script for the Self-Operating Computer (SOC) framework. 
For now only work will MacOS but also include placeholder/ function to run this on other platform like linux, windows, ...

The script performs the following operations:

- Checks for the existence of necessary commands such as Python, pip, and git, and installs them if not found.
- Clones the SOC repository if it doesn't already exist in the current directory.
- Creates and activates a Python virtual environment within the cloned repository.
- Installs the project requirements and the project itself.
- Prompts the user for their OpenAI API key and writes it to a .env file.
- On macOS, it attempts to open the Security & Privacy settings for the user to grant necessary permissions.
- Finally, it runs the SOC framework.
