### PR TITLE
Add graceful handling of ctrl-c keyboard interrupt

### DIFF
--- a/operate/main.py
+++ b/operate/main.py
@@ -618,8 +618,11 @@ def main_entry():
         default="gpt-4-vision-preview",
     )
 
-    args = parser.parse_args()
-    main(args.model)
+    try:
+        args = parser.parse_args()
+        main(args.model)
+    except KeyboardInterrupt:
+        print(f"\n{ANSI_BRIGHT_MAGENTA}Exiting...")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR handles SIGINT keyboard interrupt signals (ctrl-c) by providing a graceful exiting message rather than the traceback output. 

**Result**
![Screenshot from 2023-12-01 10-22-42](https://github.com/OthersideAI/self-operating-computer/assets/18507739/a5534438-7466-4706-81bf-8c37facfe58b)