### PR TITLE
Made `win` key default for opening menu in Linux

### DIFF
--- a/operate/main.py
+++ b/operate/main.py
@@ -545,6 +545,8 @@ def keyboard_type(text):
 def search(text):
     if platform.system() == "Windows":
         pyautogui.press("win")
+    elif platform.system() == "Linux":
+        pyautogui.press("win")
     else:
         # Press and release Command and Space separately
         pyautogui.keyDown("command")


### PR DESCRIPTION
Fixes #39 