### PR TITLE
Replace TTF search with default ImageDraw font for grid

### DIFF
--- a/operate/main.py
+++ b/operate/main.py
@@ -3,6 +3,7 @@ Self-Operating Computer
 """
 import os
 import time
+import random
 import base64
 import json
 import math
@@ -490,14 +491,13 @@ def add_grid_to_image(original_image_path, new_image_path, grid_interval):
 
     # Reduce the font size a bit
     font_size = int(grid_interval / 10)  # Reduced font size
-    font = ImageFont.truetype(font_path, size=font_size)
 
     # Calculate the background size based on the font size
     bg_width = int(font_size * 4.2)  # Adjust as necessary
     bg_height = int(font_size * 1.2)  # Adjust as necessary
 
     # Function to draw text with a white rectangle background
-    def draw_label_with_background(position, text, draw, font, bg_width, bg_height):
+    def draw_label_with_background(position, text, draw, font_size, bg_width, bg_height):
         # Adjust the position based on the background size
         text_position = (position[0] + bg_width // 2, position[1] + bg_height // 2)
         # Draw the text background
@@ -506,7 +506,7 @@ def add_grid_to_image(original_image_path, new_image_path, grid_interval):
             fill="white",
         )
         # Draw the text
-        draw.text(text_position, text, fill="black", font=font, anchor="mm")
+        draw.text(text_position, text, fill="black", font_size=font_size, anchor="mm")
 
     # Draw vertical lines and labels at every `grid_interval` pixels
     for x in range(grid_interval, width, grid_interval):
@@ -520,7 +520,7 @@ def add_grid_to_image(original_image_path, new_image_path, grid_interval):
                 (x - bg_width // 2, y - bg_height // 2),
                 f"{x_percent}%,{y_percent}%",
                 draw,
-                font,
+                font_size,
                 bg_width,
                 bg_height,
             )

--- a/operate/main.py
+++ b/operate/main.py
@@ -479,16 +479,6 @@ def add_grid_to_image(original_image_path, new_image_path, grid_interval):
     # Get the image size
     width, height = image.size
 
-    # Get the path to a TrueType font included with matplotlib
-    font_paths = fm.findSystemFonts(fontpaths=None, fontext="ttf")
-    # Filter for specific font name (e.g., 'Arial.ttf')
-    font_path = next((path for path in font_paths if "Arial" in path), None)
-    if not font_path:
-        if len(font_paths) > 0:
-            font_path = font_paths[0]
-        else:
-            raise RuntimeError("No TrueType fonts found on the system.")
-
     # Reduce the font size a bit
     font_size = int(grid_interval / 10)  # Reduced font size
 
@@ -497,7 +487,9 @@ def add_grid_to_image(original_image_path, new_image_path, grid_interval):
     bg_height = int(font_size * 1.2)  # Adjust as necessary
 
     # Function to draw text with a white rectangle background
-    def draw_label_with_background(position, text, draw, font_size, bg_width, bg_height):
+    def draw_label_with_background(
+        position, text, draw, font_size, bg_width, bg_height
+    ):
         # Adjust the position based on the background size
         text_position = (position[0] + bg_width // 2, position[1] + bg_height // 2)
         # Draw the text background


### PR DESCRIPTION
***Problem***
While experimenting with how to improve click accuracy, I discovered that sometimes the coordinates added to the grid image looked like this:

![Screenshot from 2023-12-01 12-51-51](https://github.com/OthersideAI/self-operating-computer/assets/18507739/dbb3d24d-75d4-43cb-8d65-c93a107549df)

Sometimes it would be a barely legible cursive font. I discovered that this was due to the following code:
```
# Get the path to a TrueType font included with matplotlib
font_paths = fm.findSystemFonts(fontpaths=None, fontext="ttf")
# Filter for specific font name (e.g., 'Arial.ttf')
font_path = next((path for path in font_paths if "Arial" in path), None)
if not font_path:
      if len(font_paths) > 0:
          font_path = font_paths[0]
      else:
          raise RuntimeError("No TrueType fonts found on the system.")
```

Although it is filtering for Arial, the font for the resulting grid sent to GPT-4v is non-deterministic.

***Solution***
This PR replaces searching for a TrueType font with just using the default font used by ImageDraw. In addition, the calculated font size can can be passed to ```draw.text(...)``` rather than passing a whole TTF.

This is the result:
![Screenshot from 2023-12-01 12-54-12](https://github.com/OthersideAI/self-operating-computer/assets/18507739/a325dc57-7e47-45ea-8ba5-c34abc03b5ec)

This is the font that is now used every time the grid is drawn. Since introducing this change, I've noticed a drastic improvement in click accuracy on my system (Linux).

In addition, this will prevent the exception from not having a TrueType font installed on the system.