### PR TITLE
Add OpenAI rate limiting disclaimer

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,6 @@ Stay updated with the latest developments:
 ### Compatibility
 - This project is compatible with Mac OS, Windows, and Linux (with X server installed).
 
+### OpenAI Rate Limiting Note
+The ```gpt-4-vision-preview``` model is required. To unlock access to this model, your account needs to spend at least \$5 in API credits. Pre-paying for these credits will unlock access if you haven't already spent the minimum \$5.   
+Learn more **[here](https://platform.openai.com/docs/guides/rate-limits?context=tier-one)**


### PR DESCRIPTION
This PR adds a note at the bottom of the README informing users that a minimum of $5 must be spent on their account to unlock access to ```gpt-4-vision-preview```. 

This will help to reduce issues such as #26 and #72.