### PR TITLE
Actions workflow for building and uploading package to PyPi.

### DIFF
--- a/.github/workflows/upload-package.yml
+++ b/.github/workflows/upload-package.yml
@@ -1,0 +1,34 @@
+name: Upload Python Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v3
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    - name: Build and check package
+      run: |
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+        
+    - name: Upload to PyPi
+      uses: pypa/gh-action-pypi-publish@v1.4.2
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_API_TOKEN }}
+


### PR DESCRIPTION
### Changes Proposed
This pull request aims to eliminate the need to run "pip install -r requirements.txt" and "pip install .", simplifying the installation process to just "pip install self-operating-computer" through the implementation of a GitHub Actions workflow for automatic package upload to PyPI. 

The specific changes include:

・Creation of .github/workflows/upload-package.yml, defining a GitHub Actions workflow for automating the package upload to PyPI.
・Setting the Python version to 3.8, considering compatibility with the current version of the project.

### Next Steps
Necessary changes to setup.py will be made in additional commits. This will facilitate an easier setup and execution process for users.

### Notes
・These changes are in response to the request listed in CONTRIBUTING.md to "Remove necessity for pip install .: I think by uploading packages to PyPi we can reduce the installation code steps by consolidating pip install -r requirements.txt and pip install .. If that's possible that'd be great."
・The changes are aimed at enhancing the usability and maintainability of the project.