### PR TITLE
Fixed timing with search triggering causing broken searches

### DIFF
--- a/operate/main.py
+++ b/operate/main.py
@@ -684,6 +684,8 @@ def keyboard_type(text):
 
 
 def search(text):
+    import time
+
     if platform.system() == "Windows":
         pyautogui.press("win")
     elif platform.system() == "Linux":
@@ -693,6 +695,8 @@ def search(text):
         pyautogui.keyDown("command")
         pyautogui.press("space")
         pyautogui.keyUp("command")
+
+    time.sleep(1)
 
     # Now type the text
     for char in text:


### PR DESCRIPTION
Resolves [issue 90](https://github.com/OthersideAI/self-operating-computer/issues/90).

This PR addresses an issue where the time the system takes to respond to the search hotkey is longer than it takes the app to send the search text. I added a 1-second pause in between the hotkey and text entry which seems to resolve this on a reasonably performing machine.