### PR TITLE
feat: Add installation option using .sh script

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,26 @@ https://github.com/OthersideAI/self-operating-computer/assets/42594239/9e8abc96-
 ## Quick Start Instructions
 Below are instructions to set up the Self-Operating Computer Framework locally on your computer.
 
+### Option 1: Installation using .sh script
+
+1. **Clone the repo** to a directory on your computer:
+```
+git clone https://github.com/OthersideAI/self-operating-computer.git
+```
+2. **Cd into directory**:
+
+```
+cd self-operating-computer
+```
+
+3. **Run the installation script**: 
+
+```
+./run.sh
+```
+
+### Option 2: Traditional Installation
+
 1. **Clone the repo** to a directory on your computer:
 ```
 git clone https://github.com/OthersideAI/self-operating-computer.git


### PR DESCRIPTION
## PR Request: Add Installation Option Using .sh Script

### Description
This PR introduces a new installation option using a .sh script, providing users with an alternative, more streamlined method to set up the Self-Operating Computer Framework. This addition aims to enhance user flexibility and make the installation process more accessible.

### Changes Made
- Added a new `.sh` script in the `self-operating-computer` directory: `run.sh`.
- Updated the README.md to include detailed instructions for the new installation option.
- Separated the installation options in the README to prevent users from running all commands by mistake.
