### PR TITLE
Handled error parsing JSON:'NoneType' object has no attribute

### DIFF
--- a/operate/config.py
+++ b/operate/config.py
@@ -18,8 +18,8 @@ class Config:
     def __init__(self):
         load_dotenv()
         self.verbose = False
-        self.openai_api_key = os.getenv("OPENAI_API_KEY")
-        self.google_api_key = os.getenv("GOOGLE_API_KEY")
+        self.openai_api_key = os.getenv("OPENAI_API_KEY", "")
+        self.google_api_key = os.getenv("GOOGLE_API_KEY", "")
 
     def initialize_openai(self):
         if self.openai_api_key:


### PR DESCRIPTION
## What does this PR do?

Resolves handling for json by returning empty string instead of None incase API keys are not found.

Fixes # 128


## Type of change

Bug fix (non-breaking change which fixes an issue)

